### PR TITLE
V5 hardfork

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
 && rm -rf ./build \
  # Compile cyber for v4 version
 ###########################################################################################
-&& git checkout v4.0.0 \
+&& git checkout v5.2.0 \
 && cd /sources/x/rank/cuda \
 && make build \
 && cd  /sources \

--- a/app/ante.go
+++ b/app/ante.go
@@ -219,10 +219,10 @@ func (dfd DeductFeeBandDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 
 	isDeliverTx := !ctx.IsCheckTx() && !ctx.IsReCheckTx() && !simulate
 	if isDeliverTx {
-		err = dfd.bandwidthMeter.ConsumeAccountBandwidth(ctx, accountBandwidth, txCost)
-		if err != nil {
-			return ctx, err
-		}
+		//err = dfd.bandwidthMeter.ConsumeAccountBandwidth(ctx, accountBandwidth, txCost)
+		//if err != nil {
+		//	return ctx, err
+		//}
 		dfd.bandwidthMeter.AddToBlockBandwidth(ctx, txCost)
 	}
 

--- a/app/upgrades/v5/constants.go
+++ b/app/upgrades/v5/constants.go
@@ -7,7 +7,7 @@ import (
 const (
 	UpgradeName = "v5"
 
-	UpgradeHeight = 15_700_842
+	UpgradeHeight = 15_700_805
 )
 
 var Fork = upgrades.Fork{

--- a/cmd/iavltool/cmd/root.go
+++ b/cmd/iavltool/cmd/root.go
@@ -125,7 +125,7 @@ var shapeCmd = &cobra.Command{
 			fmt.Println("ERROR DB OPEN:", err)
 		}
 
-		store := "rank"
+		store := "all"
 		version := int64(0)
 		switch len(args) {
 		case 2:
@@ -135,12 +135,23 @@ var shapeCmd = &cobra.Command{
 			store = args[0]
 		}
 
-		tree, err := ReadTree(db, version, store)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error reading data: %s\n", err)
-			os.Exit(1)
+		if store == "all" {
+			for _, name := range appStores {
+				tree, err := ReadTree(db, version, name)
+				if err != nil {
+					_, _ = fmt.Fprintf(os.Stderr, "Error reading data: %s\n", err)
+					os.Exit(1)
+				}
+				PrintShape(tree)
+			}
+		} else {
+			tree, err := ReadTree(db, version, store)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error reading data: %s\n", err)
+				os.Exit(1)
+			}
+			PrintShape(tree)
 		}
-		PrintShape(tree)
 	},
 }
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,10 +27,12 @@ then
   cp -r /cyber/cosmovisor/upgrades  /root/.cyber/cosmovisor/
 fi
 
-if [ ! -d "/root/.cyber/cosmovisor/upgrades/v4/" ]
+if [  -d "/root/.cyber/cosmovisor/upgrades/v4/" ]
 then
   cp -r /cyber/cosmovisor/upgrades/v4  /root/.cyber/cosmovisor/upgrades/v4
 fi
+
+/usr/bin/cyber rollback --home /root/.cyber
 
 if [ ! -f "/root/.cyber/config/genesis.json" ]
 then

--- a/x/bandwidth/abci.go
+++ b/x/bandwidth/abci.go
@@ -45,5 +45,5 @@ func EndBlocker(ctx sdk.Context, bm *keeper.BandwidthMeter) {
 
 	bm.CommitBlockBandwidth(ctx) // TODO add block event for committed bandwidth
 
-	updateAccountsMaxBandwidth(ctx, bm)
+	//updateAccountsMaxBandwidth(ctx, bm)
 }


### PR DESCRIPTION
**Upgrade and Build Process Updates**
* Updated the build process in the `Dockerfile` to checkout version `v5.2.0` instead of `v4.0.0`, ensuring the latest code is compiled.
* Changed the upgrade height in `app/upgrades/v5/constants.go` from `15_700_842` to `15_700_805`, aligning with the new upgrade schedule.
* Modified `entrypoint.sh` to always perform a rollback if the `v4` upgrade directory exists, and added an explicit call to `/usr/bin/cyber rollback` to ensure state consistency during upgrades.

**Bandwidth Management Changes**
* Commented out the call to `ConsumeAccountBandwidth` in `app/ante.go`, so transactions no longer consume account-specific bandwidth, but still add to block bandwidth.
* Disabled the update of accounts' maximum bandwidth in `x/bandwidth/abci.go` by commenting out the `updateAccountsMaxBandwidth` call, potentially affecting bandwidth recalculation logic.

**Tooling Improvements**
* Enhanced the `iavltool` command in `cmd/root.go` to allow inspecting the shape of all stores by default, rather than just the `rank` store, and added logic to iterate through all stores when requested. [[1]](diffhunk://#diff-41d488672218373ec18cb942adf55daafca4f62c857f91e2055a9a1eadbc6964L128-R128) [[2]](diffhunk://#diff-41d488672218373ec18cb942adf55daafca4f62c857f91e2055a9a1eadbc6964R138-R154)